### PR TITLE
Add caption copying from source platform to Telegram messages

### DIFF
--- a/app/media/downloader.py
+++ b/app/media/downloader.py
@@ -20,6 +20,7 @@ from app.media.ytdlp_profiles import PROFILES
 from app.telegram_bot.status_messenger import StatusMessenger
 from app.utils.concurrency import run_blocking
 from app.utils.filesystem import create_temp_dir, safe_cleanup
+from app.utils.validation import truncate_caption
 
 logger = logging.getLogger(__name__)
 
@@ -170,9 +171,14 @@ class Downloader:
 
             # --- Uploading ---
             await self.status_messenger.edit_message(MESSAGES["uploading"])
+
+            # Extract caption from video description
+            caption = truncate_caption(info_dict.get("description"))
+
             with video_path.open("rb") as video_file:
                 await message.reply_video(
                     video=video_file,
+                    caption=caption if caption else None,
                     supports_streaming=True,
                     read_timeout=self.settings.telegram_read_timeout,
                     write_timeout=self.settings.telegram_write_timeout,

--- a/app/utils/validation.py
+++ b/app/utils/validation.py
@@ -24,3 +24,34 @@ def validate_url(url: str) -> str:
 def enforce_size_limit(size_bytes: int):
     if size_bytes > TELEGRAM_FILE_LIMIT_MB * 1024 * 1024:
         raise SizeLimitExceeded(f"File exceeds {TELEGRAM_FILE_LIMIT_MB}MB limit")
+
+
+# Telegram caption limit is 1024 characters
+TELEGRAM_CAPTION_LIMIT = 1024
+
+
+def truncate_caption(text: str | None, max_length: int = TELEGRAM_CAPTION_LIMIT) -> str:
+    """
+    Truncates text to fit within Telegram's caption limit.
+
+    Args:
+        text: The caption text to truncate. Can be None.
+        max_length: Maximum length (default 1024 for Telegram).
+
+    Returns:
+        Truncated string, or empty string if input is None/empty.
+    """
+    if not text:
+        return ""
+
+    text = text.strip()
+    if len(text) <= max_length:
+        return text
+
+    # Truncate at word boundary if possible
+    truncated = text[: max_length - 3]
+    last_space = truncated.rfind(" ")
+    if last_space > max_length // 2:
+        truncated = truncated[:last_space]
+
+    return truncated + "..."


### PR DESCRIPTION
## Summary

Closes #3

- Extract video/post descriptions from yt-dlp metadata and include as Telegram captions
- Extract captions from gallery-dl JSON metadata for fallback downloads
- Add `truncate_caption()` utility to handle Telegram's 1024 character limit with word-boundary truncation
- Support captions for videos, slideshows, and image groups

## Changes

- `app/utils/validation.py`: Added `truncate_caption()` function
- `app/media/downloader.py`: Extract and pass caption from `info_dict["description"]`
- `app/media/gallery_dl.py`: Run with `--write-info-json`, extract caption from metadata
- `app/tests/test_validation.py`: Added 8 tests for caption truncation